### PR TITLE
Fixed typo by changing GMT-1 to GMT+1 to match the tz timezones

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To install a specific version use the `@<version>` suffix
 - `workerInterval` (Defaults to `30` in secs) : You can control at which interval the worker is checking the log's size (minimum is `1`)
 - `rotateInterval` (Defaults to `0 0 * * *` everyday at midnight): This cron is used to a force rotate when executed.
 We are using [node-schedule](https://github.com/node-schedule/node-schedule) to schedule cron, so all valid cron for [node-schedule](https://github.com/node-schedule/node-schedule) is valid cron for this option. Cron style :
-- `TZ` (Defaults to system time): This is the standard [tz database timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) used to offset the log file saved. For instance, a value of `Etc/GMT-1`, with an hourly log, will save a file at hour `14` GMT with hour `13` GMT-1 in the log name.
+- `TZ` (Defaults to system time): This is the standard [tz database timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) used to offset the log file saved. For instance, a value of `Etc/GMT+1`, with an hourly log, will save a file at hour `14` GMT with hour `13` (GMT+1) in the log name.
 
 ```
 *    *    *    *    *    *


### PR DESCRIPTION
Noticed I put GMT-1 in the README description and I described that GMT-1 should set the file name back one hour, this was wrong. The correct timezone is `Etc/GMT+1` according to the [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
