### PR TITLE
Fix compatibility with older nodejs version

### DIFF
--- a/app.js
+++ b/app.js
@@ -156,7 +156,7 @@ function proceed(file) {
 function proceed_file(file, force) {
   if (!fs.existsSync(file)) return;
   
-  if (!WATCHED_FILES.includes(file)) {
+  if (WATCHED_FILES.indexOf(file) === -1) {
     WATCHED_FILES.push(file);
   }
 


### PR DESCRIPTION
This is an easy fix for the nodejs compatibility issue. It might be, that you want to to only support newer version of node, but besides this change nothing is not working on node 4, so I think it is nice to fix this as long as node 4 is still in support by the nodejs foundation.

Fixes #85 