### PR TITLE
compatible with windows path separator \

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,8 +61,8 @@ function get_limit_size() {
 }
 
 function delete_old(file) {
-  if (file === "/dev/null") return;
-  var fileBaseName = file.substr(0, file.length - 4).split('/').pop() + "__";
+    if (file === "/dev/null") return;
+    var fileBaseName = file.substr(0, file.length - 4).split(path.sep).pop() + "__";
   var dirName = path.dirname(file);
 
   fs.readdir(dirName, function(err, files) {


### PR DESCRIPTION
In the windows environment, the separator in the file path is \ , using / to perform string splitting, the correct fileBaseName cannot be obtained, and there is a problem that the log file cannot be deleted.