### PR TITLE
fileBaseName missing '_log'. Added.

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,7 +62,7 @@ function get_limit_size() {
 
 function delete_old(file) {
   if (file === "/dev/null") return;
-  var fileBaseName = path.basename(file, '.log') + "__";
+  var fileBaseName = path.basename(file, '.log') + "_log" + "__";
   var dirName = path.dirname(file);
 
   fs.readdir(dirName, function(err, files) {


### PR DESCRIPTION
When log files are rotated the names of the new files are changed from  something.log to be with something_log__date.log. However when those are searched for to check for deletion the base checked is something__ rather than something_log__.

With this change delete_old() now checks for something_log__