### PR TITLE
feat: added feature to enable/disable rotation file retain

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ PM2 module to automatically rotate logs of processes managed by PM2.
 
 - `max_size` (Defaults to `10M`): When a file size becomes higher than this value it will rotate it (its possible that the worker check the file after it actually pass the limit) . You can specify the unit at then end: `10G`, `10M`, `10K`
 - `retain` (Defaults to `30` file logs): This number is the number of rotated logs that are keep at any one time, it means that if you have retain = 7 you will have at most 7 rotated logs and your current one.
+- `enableRetain` (Defaults to `true`): This feature if it is equal to `false`, the` retain` function will not be used
 - `compress` (Defaults to `false`): Enable compression via gzip for all rotated logs
 - `dateFormat` (Defaults to `YYYY-MM-DD_HH-mm-ss`) : Format of the data used the name the file of log
 - `rotateModule` (Defaults to `true`) : Rotate the log of pm2's module like other apps

--- a/app.js
+++ b/app.js
@@ -40,6 +40,7 @@ var WORKER_INTERVAL = isNaN(parseInt(conf.workerInterval)) ? 30 * 1000 :
 var SIZE_LIMIT = get_limit_size(); // default : 10MB
 var ROTATE_CRON = conf.rotateInterval || "0 0 * * *"; // default : every day at midnight
 var RETAIN = isNaN(parseInt(conf.retain)) ? undefined : parseInt(conf.retain); // All
+var ENABLE_RETAIN = JSON.parse(conf.enableRetain) || true;
 var COMPRESSION = JSON.parse(conf.compress) || false; // Do not compress by default
 var DATE_FORMAT = conf.dateFormat || 'YYYY-MM-DD_HH-mm-ss';
 var TZ = conf.TZ;
@@ -140,7 +141,7 @@ function proceed(file) {
       if (err) return pmx.notify(err);
       console.log('"' + final_name + '" has been created');
 
-      if (typeof(RETAIN) === 'number') 
+      if (ENABLE_RETAIN === true && typeof(RETAIN) === 'number')
         delete_old(file);
     });
   });

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "config": {
     "max_size": "10M",
     "retain": "30",
+    "enableRetain": true,
     "compress": false,
     "dateFormat": "YYYY-MM-DD_HH-mm-ss",
     "workerInterval": "30",


### PR DESCRIPTION
The added feature allows you to enable / disable the file retention functionality, so we can adopt external mechanisms for deleting old log files.
This feature if enableRetain is equal to false, the retain function will not be used.
Default: enableRetain = true